### PR TITLE
chore(qickjspp-rs): adjustments to fit quickjs into another project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,9 @@ num-traits = { version = "0.2.0", optional = true }
 log = { version = "0.4.8", optional = true }
 once_cell = "1.2.0"
 
-[workspace]
-members = [
-    "libquickjs-sys",
-]
+
+# [workspace]
+# members = [
+#     "libquickjs-sys",
+# ]
 

--- a/src/bindings/compile.rs
+++ b/src/bindings/compile.rs
@@ -4,7 +4,8 @@ use crate::ExecutionError;
 use libquickjspp_sys as q;
 use std::os::raw::c_void;
 
-use super::{make_cstring, value::JsCompiledFunction, ContextWrapper, OwnedJsValue};
+use super::value::JsCompiledFunction;
+use super::{make_cstring, ContextWrapper, OwnedJsValue};
 
 /// compile a script, will result in a JSValueRef with tag JS_TAG_FUNCTION_BYTECODE or JS_TAG_MODULE.
 ///  It can be executed with run_compiled_function().
@@ -28,7 +29,7 @@ pub fn compile<'a>(
     };
 
     // check for error
-    context.ensure_no_excpetion()?;
+    context.ensure_no_exception()?;
     Ok(value)
 }
 
@@ -45,7 +46,7 @@ pub fn run_compiled_function<'a>(
         OwnedJsValue::new(context, v)
     };
 
-    context.ensure_no_excpetion().map_err(|e| {
+    context.ensure_no_exception().map_err(|e| {
         if let ExecutionError::Internal(msg) = e {
             ExecutionError::Internal(format!("Could not evaluate compiled function: {}", msg))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,12 +38,12 @@ mod value;
 #[cfg(test)]
 mod tests;
 
-use std::{convert::TryFrom, error, fmt};
+use libquickjspp_sys::JSObject;
+use std::convert::TryFrom;
+use std::{error, fmt};
 
-pub use self::{
-    callback::{Arguments, Callback},
-    value::*,
-};
+pub use self::callback::{Arguments, Callback};
+pub use self::value::*;
 
 /// Error on Javascript execution.
 #[derive(PartialEq, Debug)]
@@ -241,6 +241,13 @@ impl Context {
         Ok(value)
     }
 
+    /// Evaluates Javascript module code and returns the value of the final expression
+    pub fn eval_mod(&self, code: &str) -> Result<JsValue, ExecutionError> {
+        let value_raw = self.wrapper.eval_mod(code)?;
+        let value = value_raw.to_value()?;
+        Ok(value)
+    }
+
     /// Evaluates Javascript code and returns the value of the final expression
     /// as a Rust type.
     ///
@@ -368,5 +375,17 @@ impl Context {
         callback: impl Callback<F> + 'static,
     ) -> Result<(), ExecutionError> {
         self.wrapper.add_callback(name, callback)
+    }
+
+    /// Exact the same as `add_callback`, but allows you to specify a namespace (object inside the
+    /// global object) to add the callback to.
+    pub fn add_callback_to_namespace<F>(
+        &self,
+        namespace: &str,
+        name: &str,
+        callback: impl Callback<F> + 'static,
+    ) -> Result<(), ExecutionError> {
+        self.wrapper
+            .add_callback_to_namespace(namespace, name, callback)
     }
 }


### PR DESCRIPTION
* chore(quickjspp-rs): remove workspace setting
* feat(quickjspp-rs): add callbacks with namespace option
* feat(quickjspp-rs): fix typo
* feat(quickjspp-rs): add `eval_mod` to support js modules